### PR TITLE
feat(src): move activities to JSON file, add CORS and request validation

### DIFF
--- a/src/activities.json
+++ b/src/activities.json
@@ -1,0 +1,83 @@
+{
+  "Chess Club": {
+    "description": "Learn strategies and compete in chess tournaments",
+    "schedule": "Fridays, 3:30 PM - 5:00 PM",
+    "max_participants": 12,
+    "participants": [
+      "michael@mergington.edu",
+      "daniel@mergington.edu"
+    ]
+  },
+  "Programming Class": {
+    "description": "Learn programming fundamentals and build software projects",
+    "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+    "max_participants": 20,
+    "participants": [
+      "emma@mergington.edu",
+      "sophia@mergington.edu"
+    ]
+  },
+  "Gym Class": {
+    "description": "Physical education and sports activities",
+    "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+    "max_participants": 30,
+    "participants": [
+      "john@mergington.edu",
+      "olivia@mergington.edu"
+    ]
+  },
+  "Soccer Team": {
+    "description": "Join the school soccer team and compete in matches",
+    "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+    "max_participants": 22,
+    "participants": [
+      "liam@mergington.edu",
+      "noah@mergington.edu"
+    ]
+  },
+  "Basketball Team": {
+    "description": "Practice and play basketball with the school team",
+    "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+    "max_participants": 15,
+    "participants": [
+      "ava@mergington.edu",
+      "mia@mergington.edu"
+    ]
+  },
+  "Art Club": {
+    "description": "Explore your creativity through painting and drawing",
+    "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+    "max_participants": 15,
+    "participants": [
+      "amelia@mergington.edu",
+      "harper@mergington.edu"
+    ]
+  },
+  "Drama Club": {
+    "description": "Act, direct, and produce plays and performances",
+    "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+    "max_participants": 20,
+    "participants": [
+      "ella@mergington.edu",
+      "scarlett@mergington.edu"
+    ]
+  },
+  "Math Club": {
+    "description": "Solve challenging problems and participate in math competitions",
+    "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+    "max_participants": 10,
+    "participants": [
+      "james@mergington.edu",
+      "benjamin@mergington.edu"
+    ]
+  },
+  "Debate Team": {
+    "description": "Develop public speaking and argumentation skills",
+    "schedule": "Fridays, 4:00 PM - 5:30 PM",
+    "max_participants": 12,
+    "participants": [
+      "charlotte@mergington.edu",
+      "henry@mergington.edu"
+    ]
+  }
+}

--- a/src/app.py
+++ b/src/app.py
@@ -5,77 +5,71 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Body
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, EmailStr
 import os
 from pathlib import Path
+import json
+import threading
+from typing import Dict, Any
 
-app = FastAPI(title="Mergington High School API",
-              description="API for viewing and signing up for extracurricular activities")
+app = FastAPI(
+    title="Mergington High School API",
+    description="API for viewing and signing up for extracurricular activities",
+)
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
-app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
-          "static")), name="static")
+app.mount(
+    "/static",
+    StaticFiles(directory=os.path.join(Path(__file__).parent, "static")),
+    name="static",
+)
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+# Data file for activities (moves activities out of source code)
+ACTIVITIES_FILE = current_dir / "activities.json"
+_lock = threading.Lock()
+
+
+def load_activities() -> Dict[str, Any]:
+    if ACTIVITIES_FILE.exists():
+        try:
+            with ACTIVITIES_FILE.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+
+def save_activities(data: Dict[str, Any]) -> None:
+    with _lock:
+        with ACTIVITIES_FILE.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+# Initialize activities from file (or keep empty dict if not present)
+activities = load_activities()
+
+
+class SignupRequest(BaseModel):
+    email: EmailStr
+
+
+class UnregisterRequest(BaseModel):
+    email: EmailStr
+
+
+# Allow CORS from local frontend during development
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000", "http://127.0.0.1:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/")
@@ -89,44 +83,47 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, body: SignupRequest = Body(...)):
+    """Sign up a student for an activity. Accepts JSON body: {"email": "..."}."""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
     activity = activities[activity_name]
 
     # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+    if body.email in activity.get("participants", []):
+        raise HTTPException(status_code=400, detail="Student is already signed up")
+
+    # Validate capacity
+    maxp = activity.get("max_participants")
+    if isinstance(maxp, int) and len(activity.get("participants", [])) >= maxp:
+        raise HTTPException(status_code=400, detail="Activity is full")
 
     # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+    with _lock:
+        activity.setdefault("participants", []).append(body.email)
+        save_activities(activities)
+
+    return JSONResponse(status_code=201, content={"message": f"Signed up {body.email} for {activity_name}"})
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(activity_name: str, body: UnregisterRequest = Body(...)):
+    """Unregister a student from an activity. Accepts JSON body: {"email": "..."}."""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
     activity = activities[activity_name]
 
     # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
+    if body.email not in activity.get("participants", []):
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
     # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+    with _lock:
+        activity.get("participants", []).remove(body.email)
+        save_activities(activities)
+
+    return {"message": f"Unregistered {body.email} from {activity_name}"}


### PR DESCRIPTION
This PR moves hard-coded activities out of `src/app.py` into a `src/activities.json` file and updates the FastAPI app to:

- Load and save activities from `src/activities.json`.
- Use Pydantic models with `EmailStr` for signup/unregister requests.
- Add simple capacity validation for activities.
- Add a thread lock to make writes safe and persist changes.
- Add CORS middleware for local frontend development.

This implements the requested Copilot-style improvements and addresses the earlier issue about making activities easier to edit without changing Python source.

Notes:
- Endpoints now expect JSON bodies for signup/unregister: `{ "email": "..." }`.
- If you prefer query parameters instead, I can add compatibility wrappers.

Closes: related local improvement task.